### PR TITLE
rearrange resources page

### DIFF
--- a/pages/guides/how_to_set_up_full_node.md
+++ b/pages/guides/how_to_set_up_full_node.md
@@ -42,7 +42,7 @@ to get the applicable Genesis state of the network.
  - https://nodestake.top/dydx
  - https://autostake.com/networks/dydx/#services
  - https://genznodes.dev/resources/snapshot/dydx
- - Also check [“Snapshot service → Snapshots](../networks/network1/resources.md#snapshot-service)
+ - Also check [Snapshot service](../networks/network1/resources.md#snapshot-service)
 
 ## Start the full node
 1. Start the full node. Note that you may need to change the `--p2p.seeds` parameter depending on the applicable v4 software blockchain network – you can find an example on [Resources page under “Seed nodes”](../networks/network1/resources.md#seed-nodes)

--- a/pages/guides/how_to_set_up_full_node.md
+++ b/pages/guides/how_to_set_up_full_node.md
@@ -30,8 +30,7 @@ to get the applicable Genesis state of the network.
  - https://dydx.rpc.kjnodes.com/genesis
  - https://rpc.dydx.nodestake.top/genesis
  - https://dydx-mainnet-rpc.autostake.com:443/genesis
- - https://dydxprotocol-rpc.genznodes.dev/genesis
- - Also check [RPC endpoints → RPC](../networks/network1/resources.md#rpc-endpoints)
+ - Also check [Full node endpoints → RPC](../networks/network1/resources.md#full-node-endpoints)
 
 ## Install Bware’s snapshot (optional but saves days)
 1. From https://bwarelabs.com/snapshots/dydx

--- a/pages/networks/network1/resources.md
+++ b/pages/networks/network1/resources.md
@@ -36,8 +36,8 @@ The above info can be found in this [`networks` repository](https://github.com/d
 | Polkachu       | `580ec248de1f41d4e50abe132b7838348db55b80@176.9.144.40:23856` <br> `90b0ee8e73d8237b06356b244ff9854d1991a1f8@65.109.115.228:23856` <br> `874b5ab53d8f5edae6674ad394f20e2b297cf73f@199.254.199.182:23856` <br> `e3aa07f6f97fcccdf57b64aa5f4f11761df3852a@15.235.160.15:23856` <br> `a879fe2926c2b8f0d86e8e973210c30b8634abb4@15.235.204.159:23856` | `Germany` <br> `Finland` <br> `Japan` <br> `Singapore` <br> `Singapore` |
 | Bware Labs     |  |  |
 | Lavender.Five  |  |  |
-| NodeStake      |  |  |
-| AutoStake      |  |  |
+| NodeStake      | `4b0b87467129127d69ea6bb13ebae1153e8f801c@3.67.197.220:26656` |  |
+| AutoStake      | `ebc272824924ea1a27ea3183dd0b9ba713494f83@dydx-mainnet-peer.autostake.com:27366` | `EU,Poland` |
 
 ## Snapshot service
 | Team           | URI                                                       | Pruning | Index |
@@ -46,8 +46,8 @@ The above info can be found in this [`networks` repository](https://github.com/d
 | Polkachu       | `https://polkachu.com/tendermint_snapshots/dydx`          | Yes     | null  |
 | KingNodes      | `https://dydx-archive-snapshot.kingnodes.com/`            | No      | kv    |
 | Lavender.Five  | `https://services.lavenderfive.com/mainnet/dydx/snapshot` | Yes     |       |
-| NodeStake      | `https://nodestake.top/dydx`                              | Yes     |       |
-| AutoStake      | `https://autostake.com/networks/dydx/#services`           | Yes     |       |
+| NodeStake      | `https://nodestake.top/dydx`                              | Yes     | null  |
+| AutoStake      | `https://autostake.com/networks/dydx/#services`           | Yes     | null  |
 
 
 ## Full node endpoints
@@ -58,8 +58,8 @@ The above info can be found in this [`networks` repository](https://github.com/d
 | Bware Labs     | `https://dydx-mainnet-full-rpc.public.blastapi.io`        |            |
 | KingNodes      | `https://dydx-ops-rpc.kingnodes.com`                      | 250 req/m  |
 | Lavender.Five  | `https://dydx-rpc.lavenderfive.com`                       |            |
-| NodeStake      | `https://rpc.dydx.nodestake.top`                          |            |
-| AutoStake      | `https://dydx-mainnet-rpc.autostake.com`                  |            |
+| NodeStake      | `https://rpc.dydx.nodestake.top`                          | 350 req/m  |
+| AutoStake      | `https://dydx-mainnet-rpc.autostake.com`                  | 4 req/s    |
 | EcoStake       | `https://rpc-dydx.ecostake.com`                           |            |
 | CosmosSpaces   | `https://rpc-dydx.cosmos-spaces.cloud`                    |            |
 | PublicNode     | `https://dydx-rpc.publicnode.com`                         |            |
@@ -72,10 +72,10 @@ The above info can be found in this [`networks` repository](https://github.com/d
 | Bware Labs     | `https://dydx-mainnet-full-lcd.public.blastapi.io`        |            |
 | KingNodes      | `https://dydx-ops-rest.kingnodes.com`                     | 250 req/m  |
 | Lavender.Five  | `https://dydx-api.lavenderfive.com`                       |            |
-| AutoStake      | `https://dydx-mainnet-lcd.autostake.com`                  |            |
+| AutoStake      | `https://dydx-mainnet-lcd.autostake.com`                  | 4 req/s    |
 | EcoStake       | `https://rest-dydx.ecostake.com`                          |            |
 | CosmosSpaces   | `https://api-dydx.cosmos-spaces.cloud`                    |            |
-| NodeStake      | `https://api.dydx.nodestake.top`                          |            |
+| NodeStake      | `https://api.dydx.nodestake.top`                          | 350 req/m  |
 | PublicNode     | `https://dydx-rest.publicnode.com`                        |            |
 | Cros-Nest      | `https://rest-dydx.cros-nest.com`                         |            |
 | Enigma         | `https://dydx-lcd.enigma-validator.com`                   |            |
@@ -87,8 +87,8 @@ The above info can be found in this [`networks` repository](https://github.com/d
 | Bware Labs     | `https://dydx-mainnet-full-grpc.public.blastapi.io:443`   |            |
 | KingNodes      | `https://dydx-ops-grpc.kingnodes.com:443`                 | 250 req/m  |
 | Lavender.Five  | `https://dydx-grpc.lavenderfive.com:443`                  |            |
-| NodeStake      | `https://grpc.dydx.nodestake.top:443`                     |            |
-| AutoStake      | `https://dydx-mainnet-grpc.autostake.com:443`             |            |
+| NodeStake      | `https://grpc.dydx.nodestake.top:443`                     | 350 req/m  |
+| AutoStake      | `https://dydx-mainnet-grpc.autostake.com:443`             | 4 req/s    |
 | CosmosSpaces   | `http://grpc-dydx.cosmos-spaces.cloud:4990`               |            |
 | PublicNode     | `https://dydx-grpc.publicnode.com:443`                    |            |
 

--- a/pages/networks/network1/resources.md
+++ b/pages/networks/network1/resources.md
@@ -29,11 +29,25 @@ The above info can be found in this [`networks` repository](https://github.com/d
 | WS    | `wss://indexer.dydx.trade/v4/ws` |
 
 
+## StateSync nodes
+| Team           |  URI                                                                                  |
+|----------------|---------------------------------------------------------------------------------------|
+| KingNodes      |  |
+| Polkachu       |  |
+| Bware Labs     |  |
+| Lavender.Five  |  |
+| NodeStake      |  |
+| AutoStake      |  |
+
 ## Snapshot service
-| Type      | URI                                                    |
-|-----------|--------------------------------------------------------|
-| StateSync | `https://dydx-mainnet-statesync-rpc.bwarelabs.com` <br> `https://polkachu.com/state_sync/dydx` <br> `https://dydx-ops-statesync.kingnodes.com/` <br> `https://services.lavenderfive.com/mainnet/dydx/statesync` <br> `https://nodestake.top/dydx` <br> `https://autostake.com/networks/dydx/#services` |
-| Snapshots | `https://bwarelabs.com/snapshots/dydx` <br> `https://polkachu.com/tendermint_snapshots/dydx` <br> `https://dydx-archive-snapshot.kingnodes.com/` <br> `https://services.lavenderfive.com/mainnet/dydx/snapshot` <br> `https://nodestake.top/dydx`  <br> `https://autostake.com/networks/dydx/#services` |
+| Team           | URI                                                       | Pruning |
+|----------------|-----------------------------------------------------------|---------|
+| Bware Labs     | `https://bwarelabs.com/snapshots/dydx`                    | Yes     |
+| Polkachu       | `https://polkachu.com/tendermint_snapshots/dydx`          | Yes     |
+| KingNodes      | `https://dydx-archive-snapshot.kingnodes.com/`            | No      |
+| Lavender.Five  | `https://services.lavenderfive.com/mainnet/dydx/snapshot` | Yes     |
+| NodeStake      | `https://nodestake.top/dydx`                              | Yes     |
+| AutoStake      | `https://autostake.com/networks/dydx/#services`           | Yes     |
 
 
 ## RPC endpoints
@@ -41,7 +55,7 @@ The above info can be found in this [`networks` repository](https://github.com/d
 |-------|-------------------------------------------------------------------------------------------|
 | RPC   | `https://dydx-dao-rpc.polkachu.com` <br> `https://dydx-mainnet-full-rpc.public.blastapi.io` <br> `https://dydx-ops-rpc.kingnodes.com` <br> `https://dydx-rpc.lavenderfive.com` <br> `https://rpc.dydx.nodestake.top` <br> `https://dydx-mainnet-rpc.autostake.com:443` <br> `https://rpc-dydx.ecostake.com:443` <br> `https://rpc-dydx.cosmos-spaces.cloud` <br> `https://dydx-rpc.publicnode.com:443` <br> `https://dydx-rpc.enigma-validator.com` |
 | REST  | `https://dydx-dao-api.polkachu.com` <br> `https://dydx-mainnet-full-lcd.public.blastapi.io` <br> `https://dydx-ops-rest.kingnodes.com` <br> `https://dydx-api.lavenderfive.com` <br> `https://dydx-mainnet-lcd.autostake.com:443` <br> `https://rest-dydx.ecostake.com:443` <br> `https://api-dydx.cosmos-spaces.cloud` <br> `https://api.dydx.nodestake.top` <br> `https://dydx-rest.publicnode.com` <br> `https://rest-dydx.cros-nest.com:443` <br> `https://dydx-lcd.enigma-validator.com` |
-| gRPC  | `dydx-dao-grpc-1.polkachu.com:23890` <br> `dydx-dao-grpc-2.polkachu.com:23890` <br> `dydx-dao-grpc-3.polkachu.com:23890` <br> `dydx-dao-grpc-4.polkachu.com:23890` <br> `dydx-dao-grpc-5.polkachu.com:23890` <br> `dydx-mainnet-full-grpc.public.blastapi.io:443` <br> `https://dydx-ops-grpc.kingnodes.com` <br> `https://dydx-grpc.lavenderfive.com` <br> `https://grpc.dydx.nodestake.top` <br> `dydx-mainnet-grpc.autostake.com:443` <br> `grpc-dydx.cosmos-spaces.cloud:4990` <br> `dydx-grpc.publicnode.com:443` |
+| gRPC  | `dydx-dao-grpc-1.polkachu.com:23890` <br> `dydx-dao-grpc-2.polkachu.com:23890` <br> `dydx-dao-grpc-3.polkachu.com:23890` <br> `dydx-dao-grpc-4.polkachu.com:23890` <br> `dydx-dao-grpc-5.polkachu.com:23890` <br> `dydx-mainnet-full-grpc.public.blastapi.io:443` <br> `dydx-ops-grpc.kingnodes.com:443` <br> `dydx-grpc.lavenderfive.com:443` <br> `grpc.dydx.nodestake.top:443` <br> `dydx-mainnet-grpc.autostake.com:443` <br> `grpc-dydx.cosmos-spaces.cloud:4990` <br> `dydx-grpc.publicnode.com:443` |
 
 
 ## Archival nodes endpoints

--- a/pages/networks/network1/resources.md
+++ b/pages/networks/network1/resources.md
@@ -30,41 +30,89 @@ The above info can be found in this [`networks` repository](https://github.com/d
 
 
 ## StateSync nodes
-| Team           |  URI                                                                                  |
-|----------------|---------------------------------------------------------------------------------------|
-| KingNodes      |  |
-| Polkachu       |  |
-| Bware Labs     |  |
-| Lavender.Five  |  |
-| NodeStake      |  |
-| AutoStake      |  |
+| Team           | StateSync Peers                                                                       | Region |
+|----------------|---------------------------------------------------------------------------------------|--------|
+| KingNodes      | `f94dcfbccb9019584d1790562a020507b050d9ba@51.77.56.23:23856` <br> `6bc1068d9a257931083ddc75ad3b1003a46e5b0d@15.235.160.127:23856` | `EU_West` <br> `Asia_SE` |
+| Polkachu       |  |  |
+| Bware Labs     |  |  |
+| Lavender.Five  |  |  |
+| NodeStake      |  |  |
+| AutoStake      |  |  |
 
 ## Snapshot service
-| Team           | URI                                                       | Pruning |
-|----------------|-----------------------------------------------------------|---------|
-| Bware Labs     | `https://bwarelabs.com/snapshots/dydx`                    | Yes     |
-| Polkachu       | `https://polkachu.com/tendermint_snapshots/dydx`          | Yes     |
-| KingNodes      | `https://dydx-archive-snapshot.kingnodes.com/`            | No      |
-| Lavender.Five  | `https://services.lavenderfive.com/mainnet/dydx/snapshot` | Yes     |
-| NodeStake      | `https://nodestake.top/dydx`                              | Yes     |
-| AutoStake      | `https://autostake.com/networks/dydx/#services`           | Yes     |
+| Team           | URI                                                       | Pruning | Index |
+|----------------|-----------------------------------------------------------|---------|-------|
+| Bware Labs     | `https://bwarelabs.com/snapshots/dydx`                    | Yes     |       |
+| Polkachu       | `https://polkachu.com/tendermint_snapshots/dydx`          | Yes     |       |
+| KingNodes      | `https://dydx-archive-snapshot.kingnodes.com/`            | No      | kv    |
+| Lavender.Five  | `https://services.lavenderfive.com/mainnet/dydx/snapshot` | Yes     |       |
+| NodeStake      | `https://nodestake.top/dydx`                              | Yes     |       |
+| AutoStake      | `https://autostake.com/networks/dydx/#services`           | Yes     |       |
 
 
-## RPC endpoints
-| Type  | URI                                                                                       |
-|-------|-------------------------------------------------------------------------------------------|
-| RPC   | `https://dydx-dao-rpc.polkachu.com` <br> `https://dydx-mainnet-full-rpc.public.blastapi.io` <br> `https://dydx-ops-rpc.kingnodes.com` <br> `https://dydx-rpc.lavenderfive.com` <br> `https://rpc.dydx.nodestake.top` <br> `https://dydx-mainnet-rpc.autostake.com:443` <br> `https://rpc-dydx.ecostake.com:443` <br> `https://rpc-dydx.cosmos-spaces.cloud` <br> `https://dydx-rpc.publicnode.com:443` <br> `https://dydx-rpc.enigma-validator.com` |
-| REST  | `https://dydx-dao-api.polkachu.com` <br> `https://dydx-mainnet-full-lcd.public.blastapi.io` <br> `https://dydx-ops-rest.kingnodes.com` <br> `https://dydx-api.lavenderfive.com` <br> `https://dydx-mainnet-lcd.autostake.com:443` <br> `https://rest-dydx.ecostake.com:443` <br> `https://api-dydx.cosmos-spaces.cloud` <br> `https://api.dydx.nodestake.top` <br> `https://dydx-rest.publicnode.com` <br> `https://rest-dydx.cros-nest.com:443` <br> `https://dydx-lcd.enigma-validator.com` |
-| gRPC  | `dydx-dao-grpc-1.polkachu.com:23890` <br> `dydx-dao-grpc-2.polkachu.com:23890` <br> `dydx-dao-grpc-3.polkachu.com:23890` <br> `dydx-dao-grpc-4.polkachu.com:23890` <br> `dydx-dao-grpc-5.polkachu.com:23890` <br> `dydx-mainnet-full-grpc.public.blastapi.io:443` <br> `dydx-ops-grpc.kingnodes.com:443` <br> `dydx-grpc.lavenderfive.com:443` <br> `grpc.dydx.nodestake.top:443` <br> `dydx-mainnet-grpc.autostake.com:443` <br> `grpc-dydx.cosmos-spaces.cloud:4990` <br> `dydx-grpc.publicnode.com:443` |
+## Full node endpoints
+### RPC
+| Team           | URI                                                       | Rate limit |
+|----------------|-----------------------------------------------------------|-------------|
+| Polkachu       | `https://dydx-dao-rpc.polkachu.com`                       |             |
+| Bware Labs     | `https://dydx-mainnet-full-rpc.public.blastapi.io`        |             |
+| KingNodes      | `https://dydx-ops-rpc.kingnodes.com`                      |             |
+| Lavender.Five  | `https://dydx-rpc.lavenderfive.com`                       |             |
+| NodeStake      | `https://rpc.dydx.nodestake.top`                          |             |
+| AutoStake      | `https://dydx-mainnet-rpc.autostake.com`                  |             |
+| EcoStake       | `https://rpc-dydx.ecostake.com`                           |             |
+| CosmosSpaces   | `https://rpc-dydx.cosmos-spaces.cloud`                    |             |
+| PublicNode     | `https://dydx-rpc.publicnode.com`                         |             |
+| Enigma         | `https://dydx-rpc.enigma-validator.com`                   |             |
 
+### REST
+| Team           | URI                                                       | Rate limit |
+|----------------|-----------------------------------------------------------|------------|
+| Polkachu       | `https://dydx-dao-api.polkachu.com`                       |            |
+| Bware Labs     | `https://dydx-mainnet-full-lcd.public.blastapi.io`        |            |
+| KingNodes      | `https://dydx-ops-rest.kingnodes.com`                     |            |
+| Lavender.Five  | `https://dydx-api.lavenderfive.com`                       |            |
+| AutoStake      | `https://dydx-mainnet-lcd.autostake.com`                  |            |
+| EcoStake       | `https://rest-dydx.ecostake.com`                          |            |
+| CosmosSpaces   | `https://api-dydx.cosmos-spaces.cloud`                    |            |
+| NodeStake      | `https://api.dydx.nodestake.top`                          |            |
+| PublicNode     | `https://dydx-rest.publicnode.com`                        |            |
+| Cros-Nest      | `https://rest-dydx.cros-nest.com`                         |            |
+| Enigma         | `https://dydx-lcd.enigma-validator.com`                   |            |
 
-## Archival nodes endpoints
-| Type  | URI                                                                                       |
-|-------|-------------------------------------------------------------------------------------------|
-| RPC   | `https://dydx-dao-archive-rpc.polkachu.com` <br> `https://dydx-mainnet-archive-rpc.public.blastapi.io` <br> `https://dydx-ops-archive-rpc.kingnodes.com` |
-| REST  | `https://dydx-dao-archive-api.polkachu.com` <br> `https://dydx-mainnet-archive-lcd.public.blastapi.io` <br> `https://dydx-ops-archive-rest.kingnodes.com` |
-| gRPC  | `dydx-dao-archive-grpc-1.polkachu.com:23890` <br> `dydx-dao-archive-grpc-2.polkachu.com:23890` <br> `dydx-mainnet-archive-grpc.public.blastapi.io:443` <br> `https://dydx-ops-archive-grpc.kingnodes.com` |
+### gRPC
+| Team           | URI                                                       | Rate limit |
+|----------------|-----------------------------------------------------------|------------|
+| Polkachu       | `http://dydx-dao-grpc-1.polkachu.com:23890` <br> `http://dydx-dao-grpc-2.polkachu.com:23890` <br> `http://dydx-dao-grpc-3.polkachu.com:23890` <br> `http://dydx-dao-grpc-4.polkachu.com:23890` <br> `http://dydx-dao-grpc-5.polkachu.com:23890`|            |
+| Bware Labs     | `https://dydx-mainnet-full-grpc.public.blastapi.io:443`   |            |
+| KingNodes      | `https://dydx-ops-grpc.kingnodes.com:443`                 |            |
+| Lavender.Five  | `https://dydx-grpc.lavenderfive.com:443`                  |            |
+| NodeStake      | `https://grpc.dydx.nodestake.top:443`                     |            |
+| AutoStake      | `https://dydx-mainnet-grpc.autostake.com:443`             |            |
+| CosmosSpaces   | `http://grpc-dydx.cosmos-spaces.cloud:4990`               |            |
+| PublicNode     | `https://dydx-grpc.publicnode.com:443`                    |            |
 
+## Archival node endpoints
+### RPC
+| Team           | URI                                                       | Rate limit |
+|----------------|-----------------------------------------------------------|------------|
+| Polkachu       | `https://dydx-dao-archive-rpc.polkachu.com`               |            |
+| Bware Labs     | `https://dydx-mainnet-archive-rpc.public.blastapi.io`     |            |
+| KingNodes      | `https://dydx-ops-archive-rpc.kingnodes.com`              |            |
+
+### REST
+| Team           | URI                                                       | Rate limit |
+|----------------|-----------------------------------------------------------|------------|
+| Polkachu       | `https://dydx-dao-archive-api.polkachu.com`               |            |
+| Bware Labs     | `https://dydx-mainnet-archive-lcd.public.blastapi.io`     |            |
+| KingNodes      | `https://dydx-ops-archive-rest.kingnodes.com`             |            |
+
+### gRPC
+| Team           | URI                                                       | Rate limit |
+|----------------|-----------------------------------------------------------|------------|
+| Polkachu       | `http://dydx-dao-archive-grpc-1.polkachu.com:23890` <br> `http://dydx-dao-archive-grpc-2.polkachu.com:23890` |            |
+| Bware Labs     | `https://dydx-mainnet-archive-grpc.public.blastapi.io:443`|            |
+| KingNodes      | `https://dydx-ops-archive-grpc.kingnodes.com:443`         |            |
 
 ## Other Links
 

--- a/pages/networks/network1/resources.md
+++ b/pages/networks/network1/resources.md
@@ -33,7 +33,7 @@ The above info can be found in this [`networks` repository](https://github.com/d
 | Team           | StateSync Peers                                                                       | Region |
 |----------------|---------------------------------------------------------------------------------------|--------|
 | KingNodes      | `f94dcfbccb9019584d1790562a020507b050d9ba@51.77.56.23:23856` <br> `6bc1068d9a257931083ddc75ad3b1003a46e5b0d@15.235.160.127:23856` | `EU_West` <br> `Asia_SE` |
-| Polkachu       |  |  |
+| Polkachu       | `580ec248de1f41d4e50abe132b7838348db55b80@176.9.144.40:23856` <br> `90b0ee8e73d8237b06356b244ff9854d1991a1f8@65.109.115.228:23856` <br> `874b5ab53d8f5edae6674ad394f20e2b297cf73f@199.254.199.182:23856` <br> `e3aa07f6f97fcccdf57b64aa5f4f11761df3852a@15.235.160.15:23856` <br> `a879fe2926c2b8f0d86e8e973210c30b8634abb4@15.235.204.159:23856` | `Germany` <br> `Finland` <br> `Japan` <br> `Singapore` <br> `Singapore` |
 | Bware Labs     |  |  |
 | Lavender.Five  |  |  |
 | NodeStake      |  |  |
@@ -43,7 +43,7 @@ The above info can be found in this [`networks` repository](https://github.com/d
 | Team           | URI                                                       | Pruning | Index |
 |----------------|-----------------------------------------------------------|---------|-------|
 | Bware Labs     | `https://bwarelabs.com/snapshots/dydx`                    | Yes     |       |
-| Polkachu       | `https://polkachu.com/tendermint_snapshots/dydx`          | Yes     |       |
+| Polkachu       | `https://polkachu.com/tendermint_snapshots/dydx`          | Yes     | null  |
 | KingNodes      | `https://dydx-archive-snapshot.kingnodes.com/`            | No      | kv    |
 | Lavender.Five  | `https://services.lavenderfive.com/mainnet/dydx/snapshot` | Yes     |       |
 | NodeStake      | `https://nodestake.top/dydx`                              | Yes     |       |
@@ -53,24 +53,24 @@ The above info can be found in this [`networks` repository](https://github.com/d
 ## Full node endpoints
 ### RPC
 | Team           | URI                                                       | Rate limit |
-|----------------|-----------------------------------------------------------|-------------|
-| Polkachu       | `https://dydx-dao-rpc.polkachu.com`                       |             |
-| Bware Labs     | `https://dydx-mainnet-full-rpc.public.blastapi.io`        |             |
-| KingNodes      | `https://dydx-ops-rpc.kingnodes.com`                      |             |
-| Lavender.Five  | `https://dydx-rpc.lavenderfive.com`                       |             |
-| NodeStake      | `https://rpc.dydx.nodestake.top`                          |             |
-| AutoStake      | `https://dydx-mainnet-rpc.autostake.com`                  |             |
-| EcoStake       | `https://rpc-dydx.ecostake.com`                           |             |
-| CosmosSpaces   | `https://rpc-dydx.cosmos-spaces.cloud`                    |             |
-| PublicNode     | `https://dydx-rpc.publicnode.com`                         |             |
-| Enigma         | `https://dydx-rpc.enigma-validator.com`                   |             |
+|----------------|-----------------------------------------------------------|------------|
+| Polkachu       | `https://dydx-dao-rpc.polkachu.com`                       | 300 req/m  |
+| Bware Labs     | `https://dydx-mainnet-full-rpc.public.blastapi.io`        |            |
+| KingNodes      | `https://dydx-ops-rpc.kingnodes.com`                      | 250 req/m  |
+| Lavender.Five  | `https://dydx-rpc.lavenderfive.com`                       |            |
+| NodeStake      | `https://rpc.dydx.nodestake.top`                          |            |
+| AutoStake      | `https://dydx-mainnet-rpc.autostake.com`                  |            |
+| EcoStake       | `https://rpc-dydx.ecostake.com`                           |            |
+| CosmosSpaces   | `https://rpc-dydx.cosmos-spaces.cloud`                    |            |
+| PublicNode     | `https://dydx-rpc.publicnode.com`                         |            |
+| Enigma         | `https://dydx-rpc.enigma-validator.com`                   |            |
 
 ### REST
 | Team           | URI                                                       | Rate limit |
 |----------------|-----------------------------------------------------------|------------|
-| Polkachu       | `https://dydx-dao-api.polkachu.com`                       |            |
+| Polkachu       | `https://dydx-dao-api.polkachu.com`                       | 300 req/m  |
 | Bware Labs     | `https://dydx-mainnet-full-lcd.public.blastapi.io`        |            |
-| KingNodes      | `https://dydx-ops-rest.kingnodes.com`                     |            |
+| KingNodes      | `https://dydx-ops-rest.kingnodes.com`                     | 250 req/m  |
 | Lavender.Five  | `https://dydx-api.lavenderfive.com`                       |            |
 | AutoStake      | `https://dydx-mainnet-lcd.autostake.com`                  |            |
 | EcoStake       | `https://rest-dydx.ecostake.com`                          |            |
@@ -83,9 +83,9 @@ The above info can be found in this [`networks` repository](https://github.com/d
 ### gRPC
 | Team           | URI                                                       | Rate limit |
 |----------------|-----------------------------------------------------------|------------|
-| Polkachu       | `http://dydx-dao-grpc-1.polkachu.com:23890` <br> `http://dydx-dao-grpc-2.polkachu.com:23890` <br> `http://dydx-dao-grpc-3.polkachu.com:23890` <br> `http://dydx-dao-grpc-4.polkachu.com:23890` <br> `http://dydx-dao-grpc-5.polkachu.com:23890`|            |
+| Polkachu       | `http://dydx-dao-grpc-1.polkachu.com:23890` <br> `http://dydx-dao-grpc-2.polkachu.com:23890` <br> `http://dydx-dao-grpc-3.polkachu.com:23890` <br> `http://dydx-dao-grpc-4.polkachu.com:23890` <br> `http://dydx-dao-grpc-5.polkachu.com:23890`| 300 req/m  |
 | Bware Labs     | `https://dydx-mainnet-full-grpc.public.blastapi.io:443`   |            |
-| KingNodes      | `https://dydx-ops-grpc.kingnodes.com:443`                 |            |
+| KingNodes      | `https://dydx-ops-grpc.kingnodes.com:443`                 | 250 req/m  |
 | Lavender.Five  | `https://dydx-grpc.lavenderfive.com:443`                  |            |
 | NodeStake      | `https://grpc.dydx.nodestake.top:443`                     |            |
 | AutoStake      | `https://dydx-mainnet-grpc.autostake.com:443`             |            |
@@ -96,23 +96,23 @@ The above info can be found in this [`networks` repository](https://github.com/d
 ### RPC
 | Team           | URI                                                       | Rate limit |
 |----------------|-----------------------------------------------------------|------------|
-| Polkachu       | `https://dydx-dao-archive-rpc.polkachu.com`               |            |
+| Polkachu       | `https://dydx-dao-archive-rpc.polkachu.com`               | 300 req/m  |
 | Bware Labs     | `https://dydx-mainnet-archive-rpc.public.blastapi.io`     |            |
-| KingNodes      | `https://dydx-ops-archive-rpc.kingnodes.com`              |            |
+| KingNodes      | `https://dydx-ops-archive-rpc.kingnodes.com`              | 50 req/m   |
 
 ### REST
 | Team           | URI                                                       | Rate limit |
 |----------------|-----------------------------------------------------------|------------|
-| Polkachu       | `https://dydx-dao-archive-api.polkachu.com`               |            |
+| Polkachu       | `https://dydx-dao-archive-api.polkachu.com`               | 300 req/m  |
 | Bware Labs     | `https://dydx-mainnet-archive-lcd.public.blastapi.io`     |            |
-| KingNodes      | `https://dydx-ops-archive-rest.kingnodes.com`             |            |
+| KingNodes      | `https://dydx-ops-archive-rest.kingnodes.com`             | 50 req/m   |
 
 ### gRPC
 | Team           | URI                                                       | Rate limit |
 |----------------|-----------------------------------------------------------|------------|
-| Polkachu       | `http://dydx-dao-archive-grpc-1.polkachu.com:23890` <br> `http://dydx-dao-archive-grpc-2.polkachu.com:23890` |            |
+| Polkachu       | `http://dydx-dao-archive-grpc-1.polkachu.com:23890` <br> `http://dydx-dao-archive-grpc-2.polkachu.com:23890` | 300 req/m  |
 | Bware Labs     | `https://dydx-mainnet-archive-grpc.public.blastapi.io:443`|            |
-| KingNodes      | `https://dydx-ops-archive-grpc.kingnodes.com:443`         |            |
+| KingNodes      | `https://dydx-ops-archive-grpc.kingnodes.com:443`         | 50 req/m   |
 
 ## Other Links
 

--- a/pages/networks/network1/resources.md
+++ b/pages/networks/network1/resources.md
@@ -34,7 +34,7 @@ The above info can be found in this [`networks` repository](https://github.com/d
 |----------------|---------------------------------------------------------------------------------------|--------|
 | KingNodes      | `f94dcfbccb9019584d1790562a020507b050d9ba@51.77.56.23:23856` <br> `6bc1068d9a257931083ddc75ad3b1003a46e5b0d@15.235.160.127:23856` | `EU_West` <br> `Asia_SE` |
 | Polkachu       | `580ec248de1f41d4e50abe132b7838348db55b80@176.9.144.40:23856` <br> `90b0ee8e73d8237b06356b244ff9854d1991a1f8@65.109.115.228:23856` <br> `874b5ab53d8f5edae6674ad394f20e2b297cf73f@199.254.199.182:23856` <br> `e3aa07f6f97fcccdf57b64aa5f4f11761df3852a@15.235.160.15:23856` <br> `a879fe2926c2b8f0d86e8e973210c30b8634abb4@15.235.204.159:23856` | `Germany` <br> `Finland` <br> `Japan` <br> `Singapore` <br> `Singapore` |
-| Bware Labs     |  |  |
+| Bware Labs     | `b0137ca9fec8d2990d804e20bc5b74e641bb45e8@dydx-mainnet-statesync-rpc.bwarelabs.com:443` | `Germany` |
 | Lavender.Five  |  |  |
 | NodeStake      | `4b0b87467129127d69ea6bb13ebae1153e8f801c@3.67.197.220:26656` |  |
 | AutoStake      | `ebc272824924ea1a27ea3183dd0b9ba713494f83@dydx-mainnet-peer.autostake.com:27366` | `EU,Poland` |
@@ -42,7 +42,7 @@ The above info can be found in this [`networks` repository](https://github.com/d
 ## Snapshot service
 | Team           | URI                                                       | Pruning | Index |
 |----------------|-----------------------------------------------------------|---------|-------|
-| Bware Labs     | `https://bwarelabs.com/snapshots/dydx`                    | Yes     |       |
+| Bware Labs     | `https://bwarelabs.com/snapshots/dydx`                    | Yes     | null  |
 | Polkachu       | `https://polkachu.com/tendermint_snapshots/dydx`          | Yes     | null  |
 | KingNodes      | `https://dydx-archive-snapshot.kingnodes.com/`            | No      | kv    |
 | Lavender.Five  | `https://services.lavenderfive.com/mainnet/dydx/snapshot` | Yes     |       |
@@ -55,7 +55,7 @@ The above info can be found in this [`networks` repository](https://github.com/d
 | Team           | URI                                                       | Rate limit |
 |----------------|-----------------------------------------------------------|------------|
 | Polkachu       | `https://dydx-dao-rpc.polkachu.com`                       | 300 req/m  |
-| Bware Labs     | `https://dydx-mainnet-full-rpc.public.blastapi.io`        |            |
+| Bware Labs     | `https://dydx-mainnet-full-rpc.public.blastapi.io`        | 20 req/s   |
 | KingNodes      | `https://dydx-ops-rpc.kingnodes.com`                      | 250 req/m  |
 | Lavender.Five  | `https://dydx-rpc.lavenderfive.com`                       |            |
 | NodeStake      | `https://rpc.dydx.nodestake.top`                          | 350 req/m  |
@@ -69,7 +69,7 @@ The above info can be found in this [`networks` repository](https://github.com/d
 | Team           | URI                                                       | Rate limit |
 |----------------|-----------------------------------------------------------|------------|
 | Polkachu       | `https://dydx-dao-api.polkachu.com`                       | 300 req/m  |
-| Bware Labs     | `https://dydx-mainnet-full-lcd.public.blastapi.io`        |            |
+| Bware Labs     | `https://dydx-mainnet-full-lcd.public.blastapi.io`        | 20 req/s   |
 | KingNodes      | `https://dydx-ops-rest.kingnodes.com`                     | 250 req/m  |
 | Lavender.Five  | `https://dydx-api.lavenderfive.com`                       |            |
 | AutoStake      | `https://dydx-mainnet-lcd.autostake.com`                  | 4 req/s    |
@@ -84,7 +84,7 @@ The above info can be found in this [`networks` repository](https://github.com/d
 | Team           | URI                                                       | Rate limit |
 |----------------|-----------------------------------------------------------|------------|
 | Polkachu       | `http://dydx-dao-grpc-1.polkachu.com:23890` <br> `http://dydx-dao-grpc-2.polkachu.com:23890` <br> `http://dydx-dao-grpc-3.polkachu.com:23890` <br> `http://dydx-dao-grpc-4.polkachu.com:23890` <br> `http://dydx-dao-grpc-5.polkachu.com:23890`| 300 req/m  |
-| Bware Labs     | `https://dydx-mainnet-full-grpc.public.blastapi.io:443`   |            |
+| Bware Labs     | `https://dydx-mainnet-full-grpc.public.blastapi.io:443`   | 20 req/s   |
 | KingNodes      | `https://dydx-ops-grpc.kingnodes.com:443`                 | 250 req/m  |
 | Lavender.Five  | `https://dydx-grpc.lavenderfive.com:443`                  |            |
 | NodeStake      | `https://grpc.dydx.nodestake.top:443`                     | 350 req/m  |
@@ -97,21 +97,21 @@ The above info can be found in this [`networks` repository](https://github.com/d
 | Team           | URI                                                       | Rate limit |
 |----------------|-----------------------------------------------------------|------------|
 | Polkachu       | `https://dydx-dao-archive-rpc.polkachu.com`               | 300 req/m  |
-| Bware Labs     | `https://dydx-mainnet-archive-rpc.public.blastapi.io`     |            |
+| Bware Labs     | `https://dydx-mainnet-archive-rpc.public.blastapi.io`     | 20 req/s   |
 | KingNodes      | `https://dydx-ops-archive-rpc.kingnodes.com`              | 50 req/m   |
 
 ### REST
 | Team           | URI                                                       | Rate limit |
 |----------------|-----------------------------------------------------------|------------|
 | Polkachu       | `https://dydx-dao-archive-api.polkachu.com`               | 300 req/m  |
-| Bware Labs     | `https://dydx-mainnet-archive-lcd.public.blastapi.io`     |            |
+| Bware Labs     | `https://dydx-mainnet-archive-lcd.public.blastapi.io`     | 20 req/s   |
 | KingNodes      | `https://dydx-ops-archive-rest.kingnodes.com`             | 50 req/m   |
 
 ### gRPC
 | Team           | URI                                                       | Rate limit |
 |----------------|-----------------------------------------------------------|------------|
 | Polkachu       | `http://dydx-dao-archive-grpc-1.polkachu.com:23890` <br> `http://dydx-dao-archive-grpc-2.polkachu.com:23890` | 300 req/m  |
-| Bware Labs     | `https://dydx-mainnet-archive-grpc.public.blastapi.io:443`|            |
+| Bware Labs     | `https://dydx-mainnet-archive-grpc.public.blastapi.io:443`| 20 req/s   |
 | KingNodes      | `https://dydx-ops-archive-grpc.kingnodes.com:443`         | 50 req/m   |
 
 ## Other Links


### PR DESCRIPTION
1. split the statesync section: we need to have node ID to the statesync information, not a URL to the RPC nodes
2. Add Index column to the snapshot services
3. Add rate limits
4. make gRPC nodes homogenous: use IP:PORT notation